### PR TITLE
Add another executable using the windows subsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.res
 *.a
 raylua_e.exe
+raylua_r.exe
 raylua_s.exe
 raylua_s
 raylua_e

--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ USE_EXTERNAL_GLFW ?= FALSE
 
 ifeq ($(OS),Windows_NT)
 	LDFLAGS += -lopengl32 -lgdi32 -lwinmm -static
+	LDFLAGS_R += -mwindows 
 	EXTERNAL_FILES := src/res/icon.res
 else ifeq ($(shell uname),Darwin)
 	LDFLAGS += -framework CoreVideo -framework IOKit -framework Cocoa \
@@ -65,7 +66,7 @@ raylua_e: src/raylua_e.o src/raylua_self.o src/raylua_builder.o src/lib/miniz.o 
 
 raylua_r: src/raylua_e.o src/raylua_self.o src/raylua_builder.o src/lib/miniz.o \
 		$(EXTERNAL_FILES) libraylua.a
-	$(CC) -o $@ $^ $(LDFLAGS) -mwindows luajit/src/libluajit.a
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDFLAGS_R) luajit/src/libluajit.a
 
 src/res/icon.res: src/res/icon.rc
 	$(WINDRES) $^ -O coff $@

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ MODULES := raymath rlgl easings gestures physac raygui
 PLATFORM ?= PLATFORM_DESKTOP
 GRAPHICS ?= GRAPHICS_API_OPENGL_33
 
-CFLAGS += -D$(GRAPHICS)
+CFLAGS += -D$(GRAPHICS) -D$(PLATFORM)
 
 USE_WAYLAND_DISPLAY ?= FALSE
 USE_EXTERNAL_GLFW ?= FALSE
@@ -38,7 +38,7 @@ else
 	EXTERNAL_FILES :=
 endif
 
-all: raylua_s raylua_e luajit raylib
+all: raylua_s raylua_e raylua_r luajit raylib
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
@@ -62,6 +62,10 @@ raylua_s: src/raylua_s.o $(EXTERNAL_FILES) libraylua.a
 raylua_e: src/raylua_e.o src/raylua_self.o src/raylua_builder.o src/lib/miniz.o \
 		$(EXTERNAL_FILES) libraylua.a
 	$(CC) -o $@ $^ $(LDFLAGS) luajit/src/libluajit.a
+
+raylua_r: src/raylua_e.o src/raylua_self.o src/raylua_builder.o src/lib/miniz.o \
+		$(EXTERNAL_FILES) libraylua.a
+	$(CC) -o $@ $^ $(LDFLAGS) -mwindows luajit/src/libluajit.a
 
 src/res/icon.res: src/res/icon.rc
 	$(WINDRES) $^ -O coff $@


### PR DESCRIPTION
When packaging UI tools I'd like to hide the windows terminal. 

This PR adds one more executable (raylua_r.exe) which will use the windows subsystem instead of the console subsystem

I'm not sure if one more executable is the right approach for the other platforms, on windows that's the only way I'm aware of.