### PR TITLE
Fix the build

### DIFF
--- a/src/raylua_e.c
+++ b/src/raylua_e.c
@@ -195,7 +195,7 @@ int main(int argc, const char **argv)
     return 1;
   }
 
-  SetLoadFileDataCallback(raylua_loadFileData);
+  SetLoadFileDataCallback((unsigned char *(*)(const char *, int *)) raylua_loadFileData);
   SetLoadFileTextCallback(raylua_loadFileText);
 
   if (!raylua_init_payload(self)) {


### PR DESCRIPTION
I tried running `make` on my M1 Mac and got this error:

```
ar rcu libraylua.a src/raylua.o
cc -o raylua_s src/raylua_s.o libraylua.a -O2 -s -lm luajit/src/libluajit.a raylib/src/libraylib.a -framework CoreVideo -framework IOKit -framework Cocoa -framework GLUT -framework OpenGL  luajit/src/libluajit.a
ld: warning: -s is obsolete
ld: warning: ignoring duplicate libraries: 'luajit/src/libluajit.a'
cc -c -o src/raylua_e.o src/raylua_e.c -O2 -s -Iluajit/src -Iraylib/src -Iraygui/src -Iphysac/src -DGRAPHICS_API_OPENGL_33 -DPLATFORM_DESKTOP -target arm64-apple-macos11
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
src/raylua_e.c:198:27: error: incompatible function pointer types passing 'unsigned char *(const char *, unsigned int *)' to parameter of type 'LoadFileDataCallback' (aka 'unsigned char *(*)(const char *, int *)') [-Wincompatible-function-pointer-types]
  SetLoadFileDataCallback(raylua_loadFileData);
                          ^~~~~~~~~~~~~~~~~~~
raylib/src/raylib.h:1092:57: note: passing argument to parameter 'callback' here
RLAPI void SetLoadFileDataCallback(LoadFileDataCallback callback); // Set custom file binary data loader
                                                        ^
1 error generated.
make: *** [src/raylua_e.o] Error 1
```

So I fixed the types (by casting) in `src/raylua_e.c` and was able to compile and use `raylua_e` 🎉 . Looking further into the project, this seems the incorrect approach for the fix, the bindings might be wrong in `tools/autocomplete/api/raylib_api.lua` (line 3033, `LoadFileDataCallback` definition). Though I tried changing the types there and (even after `make clean`) the build still gives the same error.

This fixes the build for whoever needs it, but it's not the correct way to do it. If you can help me to fix it in the right place, I can change the Pull Request right away 🙂 